### PR TITLE
Load PageSettings based on PrinterSettings

### DIFF
--- a/PdfiumPrinter/PdfPrinter.cs
+++ b/PdfiumPrinter/PdfPrinter.cs
@@ -15,7 +15,7 @@ namespace PdfiumPrinter
             {
                 PrinterName = printerName
             };
-            PageSettings = new PageSettings()
+            PageSettings = new PageSettings(Settings)
             {
                 Margins = new Margins(0, 0, 0, 0)
             };


### PR DESCRIPTION
First thanks for this great library!

I noticed one issue.
The PageSettings should be instantiated with the PrinterSettings as parameter.
Otherwise the PageSettings of the standard printer are always loaded
instead of those of the printer with the given name.