### PR TITLE
Change calling convention to Cdcel

### DIFF
--- a/PdfiumPrinter/NativeMethods.Pdfium.cs
+++ b/PdfiumPrinter/NativeMethods.Pdfium.cs
@@ -535,203 +535,203 @@ namespace PdfiumPrinter
 
         private static class Imports
         {
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_InitLibrary();
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_DestroyLibrary();
 
-            [DllImport("pdfium", CharSet = CharSet.Ansi)]
+            [DllImport("pdfium", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDF_LoadCustomDocument([MarshalAs(UnmanagedType.LPStruct)]FPDF_FILEACCESS access, string password);
 
-            [DllImport("pdfium", CharSet = CharSet.Ansi)]
+            [DllImport("pdfium", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDF_LoadMemDocument(SafeHandle data_buf, int size, string password);
 
-            [DllImport("pdfium", CharSet = CharSet.Ansi)]
+            [DllImport("pdfium", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDF_LoadMemDocument(byte[] data_buf, int size, string password);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_CloseDocument(IntPtr document);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern int FPDF_GetPageCount(IntPtr document);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern uint FPDF_GetDocPermissions(IntPtr document);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFDOC_InitFormFillEnvironment(IntPtr document, FPDF_FORMFILLINFO formInfo);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_SetFormFieldHighlightColor(IntPtr hHandle, int fieldType, uint color);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_SetFormFieldHighlightAlpha(IntPtr hHandle, byte alpha);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FORM_DoDocumentJSAction(IntPtr hHandle);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FORM_DoDocumentOpenAction(IntPtr hHandle);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFDOC_ExitFormFillEnvironment(IntPtr hHandle);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FORM_DoDocumentAAction(IntPtr hHandle, FPDFDOC_AACTION aaType);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDF_LoadPage(IntPtr document, int page_index);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFText_LoadPage(IntPtr page);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FORM_OnAfterLoadPage(IntPtr page, IntPtr _form);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FORM_DoPageAAction(IntPtr page, IntPtr _form, FPDFPAGE_AACTION fPDFPAGE_AACTION);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern double FPDF_GetPageWidth(IntPtr page);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern double FPDF_GetPageHeight(IntPtr page);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FORM_OnBeforeClosePage(IntPtr page, IntPtr _form);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFText_ClosePage(IntPtr text_page);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_ClosePage(IntPtr page);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_RenderPage(IntPtr dc, IntPtr page, int start_x, int start_y, int size_x, int size_y, int rotate, FPDF flags);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_RenderPageBitmap(IntPtr bitmapHandle, IntPtr page, int start_x, int start_y, int size_x, int size_y, int rotate, FPDF flags);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern int FPDF_GetPageSizeByIndex(IntPtr document, int page_index, out double width, out double height);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFBitmap_CreateEx(int width, int height, int format, IntPtr first_scan, int stride);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFBitmap_FillRect(IntPtr bitmapHandle, int left, int top, int width, int height, uint color);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFBitmap_Destroy(IntPtr bitmapHandle);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFText_FindStart(IntPtr page, byte[] findWhat, FPDF_SEARCH_FLAGS flags, int start_index);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern int FPDFText_GetSchResultIndex(IntPtr handle);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern int FPDFText_GetSchCount(IntPtr handle);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern int FPDFText_GetText(IntPtr page, int start_index, int count, byte[] result);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFText_GetCharBox(IntPtr page, int index, out double left, out double right, out double bottom, out double top);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern int FPDFText_CountChars(IntPtr page);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool FPDFText_FindNext(IntPtr handle);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFText_FindClose(IntPtr handle);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool FPDFLink_Enumerate(IntPtr page, ref int startPos, out IntPtr linkAnnot);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFLink_GetDest(IntPtr document, IntPtr link);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern uint FPDFDest_GetDestPageIndex(IntPtr document, IntPtr dest);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool FPDFLink_GetAnnotRect(IntPtr linkAnnot, FS_RECTF rect);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_DeviceToPage(IntPtr page, int start_x, int start_y, int size_x, int size_y, int rotate, int device_x, int device_y, out double page_x, out double page_y);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_PageToDevice(IntPtr page, int start_x, int start_y, int size_x, int size_y, int rotate, double page_x, double page_y, out int device_x, out int device_y);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFLink_GetAction(IntPtr link);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern uint FPDFAction_GetURIPath(IntPtr document, IntPtr action, StringBuilder buffer, uint buflen);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFBookmark_GetFirstChild(IntPtr document, IntPtr bookmark);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFBookmark_GetNextSibling(IntPtr document, IntPtr bookmark);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern uint FPDFBookmark_GetTitle(IntPtr bookmark, byte[] buffer, uint buflen);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFBookmark_GetDest(IntPtr document, IntPtr bookmark);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern uint FPDF_GetLastError();
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern uint FPDF_GetMetaText(IntPtr document, string tag, byte[] buffer, uint buflen);
 
             #region Save/Edit APIs
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool FPDF_ImportPages(IntPtr destDoc, IntPtr srcDoc, [MarshalAs(UnmanagedType.LPStr)]string pageRange, int index);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool FPDF_SaveAsCopy(IntPtr doc,
                 [MarshalAs(UnmanagedType.LPStruct)]FPDF_FILEWRITE writer,
                 [MarshalAs(UnmanagedType.I4)]FPDF_SAVE_FLAGS flag);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFPage_New(IntPtr doc, int index, double width, double height);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFPage_Delete(IntPtr doc, int index);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern int FPDFPage_GetRotation(IntPtr page);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFPage_SetRotation(IntPtr page, int rotate);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDF_CreateNewDocument();
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr FPDFPageObj_NewImgeObj(IntPtr document);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool FPDFImageObj_SetBitmap(IntPtr pages, int count, IntPtr imageObject, IntPtr bitmap);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFPageObj_Transform(IntPtr page, double a, double b, double c, double d, double e, double f);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDFPage_InsertObject(IntPtr page, IntPtr pageObject);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool FPDFPage_GenerateContent(IntPtr page);
 
-            [DllImport("pdfium")]
+            [DllImport("pdfium", CallingConvention = CallingConvention.Cdecl)]
             public static extern void FPDF_FFLDraw(IntPtr form, IntPtr bitmap, IntPtr page, int start_x, int start_y, int size_x, int size_y, int rotate, FPDF flags);
 
             #endregion


### PR DESCRIPTION
The default DllImport calling convention is Winapi, which defaults to Stdcall. x86 C++ libraries however use Cdecl as calling convention instead.

See also: https://learn.microsoft.com/en-us/dotnet/standard/native-interop/calling-conventions#platform-default-calling-convention

This solves `pInvokeStackImbalance` "exceptions" while debugging, see also: https://stackoverflow.com/a/3506938/1034248